### PR TITLE
rootを追加、controllerを作成時不要なファイルが生成しないように設定

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,11 @@ Bundler.require(*Rails.groups)
 
 module ChatSpace
   class Application < Rails::Application
+    config.generators do |g|
+      g.javascripts false
+      g.helper false
+      g.test_framework false
+    end
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
+  root 'messages#index'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
# what
rootを設定
# why
仮置きで設定するため。conntrollerをgenerateした際に不要なファイルが作成されないようにするため。